### PR TITLE
Fixes #4

### DIFF
--- a/book/expandable-chapters.js
+++ b/book/expandable-chapters.js
@@ -8,7 +8,7 @@ require(['gitbook', 'jQuery'], function(gitbook, $) {
     // adding the trigger element to each ARTICLES parent and binding the event
     $(ARTICLES)
       .parent(CHAPTER)
-      .children('a')
+      .children('a,span')
       .append(
         $(TRIGGER_TEMPLATE)
           .on('click', function(e) {


### PR DESCRIPTION
When a chapter has an empty page, the trigger template needs to be added to the 'span' instead of the 'a', as there is no 'a'