### PR TITLE
Make items in sidebar navigation without a linked article 'clickable'

### DIFF
--- a/book/expandable-chapters.css
+++ b/book/expandable-chapters.css
@@ -16,6 +16,7 @@
 .book .book-summary ul.summary li a,
 .book .book-summary ul.summary li span {
 	padding-left: 30px;
+	cursor: pointer;
 }
 
 .book .book-summary .exc-trigger:before {

--- a/book/expandable-chapters.js
+++ b/book/expandable-chapters.js
@@ -9,14 +9,15 @@ require(['gitbook', 'jQuery'], function(gitbook, $) {
     $(ARTICLES)
       .parent(CHAPTER)
       .children('a,span')
-      .append(
-        $(TRIGGER_TEMPLATE)
-          .on('click', function(e) {
-            e.preventDefault();
-            e.stopPropagation();
-            toggle($(e.target).closest(CHAPTER));
-          })
-      );
+      .append(TRIGGER_TEMPLATE)
+      .on('click', function(e) {
+        if (!$(e.target).is('a')) {
+          e.preventDefault();
+          e.stopPropagation();
+          toggle($(e.target).closest(CHAPTER));
+        }
+      });
+
     expand(lsItem());
     //expand current selected chapter with it's parents
     var activeChapter = $(CHAPTER + '.active');


### PR DESCRIPTION
Items in SUMMARY.md without an associated link aren't clickable and do not expand when clicked. This pull request fixes that.